### PR TITLE
Add categories to the atom and rss feeds

### DIFF
--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="{{ lang }}">
+    <title>{{ config.title }}
+    {%- if term %} - {{ term.name }}
+    {%- elif section.title %} - {{ section.title }}
+    {%- endif -%}
+    </title>
+    {%- if config.description %}
+    <subtitle>{{ config.description }}</subtitle>
+    {%- endif %}
+    <link rel="self" type="application/atom+xml" href="{{ feed_url | safe }}"/>
+    <link rel="alternate" type="text/html" href="
+      {%- if section -%}
+        {{ section.permalink | escape_xml | safe }}
+      {%- else -%}
+        {{ config.base_url | escape_xml | safe }}
+      {%- endif -%}
+    "/>
+    <generator uri="https://www.getzola.org/">Zola</generator>
+    <updated>{{ last_updated | date(format="%+") }}</updated>
+    <id>{{ feed_url | safe }}</id>
+    {%- for page in pages %}
+    <entry xml:lang="{{ page.lang }}">
+        <title>{{ page.title }}</title>
+        <published>{{ page.date | date(format="%+") }}</published>
+        <updated>{{ page.updated | default(value=page.date) | date(format="%+") }}</updated>
+        {% for author in page.authors %}
+        <author>
+          <name>
+            {{ author }}
+          </name>
+        </author>
+        {% else %}
+        <author>
+          <name>
+            {%- if config.author -%}
+              {{ config.author }}
+            {%- else -%}
+              Unknown
+            {%- endif -%}
+          </name>
+        </author>
+        {% endfor %}
+        <link rel="alternate" type="text/html" href="{{ page.permalink | safe }}"/>
+        <id>{{ page.permalink | safe }}</id>
+        {% if page.summary %}
+        <summary type="html">{{ page.summary }}</summary>
+        {% else %}
+        <content type="html" xml:base="{{ page.permalink | escape_xml | safe }}">{{ page.content }}</content>
+        {% endif %}
+    </entry>
+    {%- endfor %}
+</feed>

--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -46,6 +46,11 @@
         {% if page.summary %}
         <summary type="html">{{ page.summary }}</summary>
         {% else %}
+        {%- if page.taxonomies.tags %}
+        {%- for tag in page.taxonomies.tags %}
+        <category term="{{ tag | safe }}" schema="tag" label="{{ tag | safe }}"/>
+        {%- endfor %}
+        {%- endif %}
         <content type="html" xml:base="{{ page.permalink | escape_xml | safe }}">{{ page.content }}</content>
         {% endif %}
     </entry>

--- a/templates/rss.xml
+++ b/templates/rss.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+    <channel>
+      <title>{{ config.title }}
+        {%- if term %} - {{ term.name }}
+        {%- elif section.title %} - {{ section.title }}
+        {%- endif -%}
+      </title>
+      <link>
+        {%- if section -%}
+          {{ section.permalink | escape_xml | safe }}
+        {%- else -%}
+          {{ config.base_url | escape_xml | safe }}
+        {%- endif -%}
+      </link>
+      <description>{{ config.description }}</description>
+      <generator>Zola</generator>
+      <language>{{ lang }}</language>
+      <atom:link href="{{ feed_url | safe }}" rel="self" type="application/rss+xml"/>
+      <lastBuildDate>{{ last_updated | date(format="%a, %d %b %Y %H:%M:%S %z") }}</lastBuildDate>
+      {%- for page in pages %}
+      <item>
+          <title>{{ page.title }}</title>
+          <pubDate>{{ page.date | date(format="%a, %d %b %Y %H:%M:%S %z") }}</pubDate>
+          <author>
+            {%- if page.authors -%}
+              {{ page.authors[0] }}
+            {%- elif config.author -%}
+              {{ config.author }}
+            {%- else -%}
+              Unknown
+            {%- endif -%}
+          </author>
+          <link>{{ page.permalink | escape_xml | safe }}</link>
+          <guid>{{ page.permalink | escape_xml | safe }}</guid>
+          <description xml:base="{{ page.permalink | escape_xml | safe }}">{% if page.summary %}{{ page.summary }}{% else %}{{ page.content }}{% endif %}</description>
+      </item>
+      {%- endfor %}
+    </channel>
+</rss>

--- a/templates/rss.xml
+++ b/templates/rss.xml
@@ -34,6 +34,11 @@
           <link>{{ page.permalink | escape_xml | safe }}</link>
           <guid>{{ page.permalink | escape_xml | safe }}</guid>
           <description xml:base="{{ page.permalink | escape_xml | safe }}">{% if page.summary %}{{ page.summary }}{% else %}{{ page.content }}{% endif %}</description>
+          {%- if page.taxonomies.tags %}
+          {%- for tag in page.taxonomies.tags %}
+          <category domain="tag">{{ tag | safe }}</category>
+          {%- endfor %}
+          {%- endif %}
       </item>
       {%- endfor %}
     </channel>


### PR DESCRIPTION
In Atom, this adds elements like:
```
    <category term="simulation" schema="tag" label="simulation"/>
```

In RSS, this adds elements like:
```
    <category domain="tag">simulation</category>
```

The point of this is to allow filtering down to simulation-related posts in an RSS aggregator.

There's two commits so that you can see the changes vs the default template from zola.